### PR TITLE
Implement std::io::Writer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 use std::cmp;
 use std::slice;
 
+pub mod writer;
+
 static BIT_REV_U8: [u8; 256] = [
     0b0000_0000, 0b1000_0000, 0b0100_0000, 0b1100_0000,
     0b0010_0000, 0b1010_0000, 0b0110_0000, 0b1110_0000,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,58 @@
+use std::io::{Write, Error, ErrorKind};
+use std::io;
+use InflateStream;
+
+pub struct InflateWriter<W: Write> {
+    inflater: InflateStream,
+    writer: W
+}
+
+impl<W: Write> InflateWriter<W> {
+    pub fn new(w: W) -> InflateWriter<W> {
+        InflateWriter { inflater: InflateStream::new(), writer: w }
+    }
+
+    pub fn finish(mut self) -> io::Result<W> {
+        self.flush()?;
+        Ok(self.writer)
+    }
+}
+
+fn update<'a>(inflater: &'a mut InflateStream, buf: &[u8]) -> io::Result<(usize, &'a [u8])>  {
+    match inflater.update(buf) {
+        Ok(res) => Ok(res),
+        Err(m) => return Err(Error::new(ErrorKind::Other, m)),
+    }
+}
+impl<W: Write> Write for InflateWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut n = 0;
+        while n < buf.len() {
+            let (num_bytes_read, result) = update(&mut self.inflater, &buf[n..])?;
+            n += num_bytes_read;
+            self.writer.write(result)?;
+        }
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let (_, result) = update(&mut self.inflater, &[])?;
+        self.writer.write(result)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::InflateWriter;
+    use std::io::Write;
+
+    #[test]
+    fn inflate_writer() {
+       let encoded = [243, 72, 205, 201, 201, 215, 81, 40, 207, 47, 202, 73, 1, 0];
+       let mut decoder = InflateWriter::new(Vec::new());
+       decoder.write(&encoded).unwrap();
+       let decoded = decoder.finish().unwrap();
+       assert!(String::from_utf8(decoded).unwrap() == "Hello, world");
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,6 +2,23 @@ use std::io::{Write, Error, ErrorKind};
 use std::io;
 use InflateStream;
 
+/// A DEFLATE decoder.
+///
+/// A struct implementing the `std::io::Write` trait that decompresses DEFLATE
+/// encoded data into the given writer `w`.
+///
+/// # Example
+///
+/// ```
+/// use inflate::writer::InflateWriter;
+/// use std::io::Write;
+///
+/// let encoded = [243, 72, 205, 201, 201, 215, 81, 40, 207, 47, 202, 73, 1, 0];
+/// let mut decoder = InflateWriter::new(Vec::new());
+/// decoder.write(&encoded).unwrap();
+/// let decoded = decoder.finish().unwrap();
+/// println!("{}", std::str::from_utf8(&decoded).unwrap()); // prints "Hello, world"
+/// ```
 pub struct InflateWriter<W: Write> {
     inflater: InflateStream,
     writer: W

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -13,7 +13,7 @@ impl<W: Write> InflateWriter<W> {
     }
 
     pub fn finish(mut self) -> io::Result<W> {
-        self.flush()?;
+        try!(self.flush());
         Ok(self.writer)
     }
 }
@@ -28,7 +28,7 @@ impl<W: Write> Write for InflateWriter<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let mut n = 0;
         while n < buf.len() {
-            let (num_bytes_read, result) = update(&mut self.inflater, &buf[n..])?;
+            let (num_bytes_read, result) = try!(update(&mut self.inflater, &buf[n..]));
             n += num_bytes_read;
             self.writer.write(result)?;
         }
@@ -36,8 +36,8 @@ impl<W: Write> Write for InflateWriter<W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        let (_, result) = update(&mut self.inflater, &[])?;
-        self.writer.write(result)?;
+        let (_, result) = try!(update(&mut self.inflater, &[]));
+        try!(self.writer.write(result));
         Ok(())
     }
 }


### PR DESCRIPTION
Hey, I'm really new to Rust, so please have that in mind for this PR :smile: 

I'm planning on using this library in my project, where I'm also using [deflate-rs](https://github.com/oyvindln/deflate-rs) and noticed that `InflateStream` didn't implement `std::io::Writer`. So I added a new struct, `InflateWriter`, that wraps an `InflateStream` and also implements `std::io::Writer`.

What do you guys think? Is this the right approach? Or would you prefer that `InflateStream` implement `std::io::Writer` directly? I'm also not sure if `pub mod writer` is the right thing to do in `src/lib.rs`...