### PR TITLE
Add support for zlib headers and trailers for InflateWriter

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -29,6 +29,10 @@ impl<W: Write> InflateWriter<W> {
         InflateWriter { inflater: InflateStream::new(), writer: w }
     }
 
+    pub fn from_zlib(w: W) -> InflateWriter<W> {
+        InflateWriter { inflater: InflateStream::from_zlib(), writer: w }
+    }
+
     pub fn finish(mut self) -> io::Result<W> {
         try!(self.flush());
         Ok(self.writer)
@@ -71,5 +75,14 @@ mod test {
        decoder.write(&encoded).unwrap();
        let decoded = decoder.finish().unwrap();
        assert!(String::from_utf8(decoded).unwrap() == "Hello, world");
+    }
+
+    #[test]
+    fn inflate_writer_from_zlib() {
+       let encoded = [120, 156, 243, 72, 205, 201, 201, 215, 81, 168, 202, 201, 76, 82, 4, 0, 27, 101, 4, 19];
+       let mut decoder = InflateWriter::from_zlib(Vec::new());
+       decoder.write(&encoded).unwrap();
+       let decoded = decoder.finish().unwrap();
+       assert!(String::from_utf8(decoded).unwrap() == "Hello, zlib!");
     }
 }


### PR DESCRIPTION
Sorry, I realized I forgot to add a constructor to `InflateWriter` in #7 in order to support compressed data with zlib headers and trailers...I also added a small test for the new constructor.