### PR TITLE
Add convenience functions for inflating data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,9 @@ use std::cmp;
 use std::slice;
 
 pub mod writer;
-pub mod utils;
+
+mod utils;
+pub use self::utils::{inflate_bytes, inflate_bytes_zlib};
 
 static BIT_REV_U8: [u8; 256] = [
     0b0000_0000, 0b1000_0000, 0b0100_0000, 0b1100_0000,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ use std::cmp;
 use std::slice;
 
 pub mod writer;
+pub mod utils;
 
 static BIT_REV_U8: [u8; 256] = [
     0b0000_0000, 0b1000_0000, 0b0100_0000, 0b1100_0000,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ fn inflate(inflater: &mut InflateStream, data: &[u8]) -> Result<Vec<u8>, String>
     while n < data.len() {
         let (num_bytes_read, bytes) = try!(inflater.update(&data[n..]));
         n += num_bytes_read;
-        decoded.extend(bytes);
+        decoded.extend(bytes.iter().map(|v| *v));
     }
 
     Ok(decoded)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,53 @@
+/// Convenience functions for inflating DEFLATE compressed data.
+///
+/// # Example
+/// ```
+/// use inflate::utils::inflate_bytes;
+/// use std::str::from_utf8;
+///
+/// let encoded = [243, 72, 205, 201, 201, 215, 81, 40, 207, 47, 202, 73, 1, 0];
+/// let decoded = inflate_bytes(&encoded).unwrap();
+/// println!("{}", from_utf8(&decoded).unwrap()); // prints "Hello, world"
+/// ```
+
+use InflateStream;
+
+fn inflate(inflater: &mut InflateStream, data: &[u8]) -> Result<Vec<u8>, String> {
+    let mut decoded = Vec::<u8>::new();
+
+    let mut n = 0;
+    while n < data.len() {
+        let (num_bytes_read, bytes) = try!(inflater.update(&data[n..]));
+        n += num_bytes_read;
+        decoded.extend(bytes);
+    }
+
+    Ok(decoded)
+}
+
+/// Decompress the given slice of DEFLATE compressed data.
+///
+/// Returns a `Vec` with the decompressed data or an error message.
+pub fn inflate_bytes(data: &[u8]) -> Result<Vec<u8>, String> {
+    inflate(&mut InflateStream::new(), data)
+}
+
+/// Decompress the given slice of DEFLATE compressed (with zlib headers and trailers) data.
+///
+/// Returns a `Vec` with the decompressed data or an error message.
+pub fn inflate_bytes_zlib(data: &[u8]) -> Result<Vec<u8>, String> {
+    inflate(&mut InflateStream::from_zlib(), data)
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn inflate_bytes_with_zlib() {
+        use super::inflate_bytes_zlib;
+        use std::str::from_utf8;
+
+        let encoded = [120, 156, 243, 72, 205, 201, 201, 215, 81, 168, 202, 201, 76, 82, 4, 0, 27, 101, 4, 19];
+        let decoded = inflate_bytes_zlib(&encoded).unwrap();
+        assert!(from_utf8(&decoded).unwrap() == "Hello, zlib!");
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@
 ///
 /// # Example
 /// ```
-/// use inflate::utils::inflate_bytes;
+/// use inflate::inflate_bytes;
 /// use std::str::from_utf8;
 ///
 /// let encoded = [243, 72, 205, 201, 201, 215, 81, 40, 207, 47, 202, 73, 1, 0];


### PR DESCRIPTION
I added a new module `utils` with the convenience functions `inflate_bytes` and `inflate_bytes_zlib` (following the naming convention from [oyvindln/deflate-rs](https://github.com/oyvindln/deflate-rs)). I also added documentation as well as one doc test and one regular test.

I could base this on the `InflateWriter` introduced in #7, but that requires `use std::io`. Would you guys prefer that? As the patch is now, the code only requires `InflateStream` (which in turn only requires `std::cmp` and `std::slice`).

This also fixes #6. 