### PR TITLE
Un-pub the writer module and expose InflateWriter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,8 @@
 use std::cmp;
 use std::slice;
 
-pub mod writer;
+mod writer;
+pub use self::writer::{InflateWriter};
 
 mod utils;
 pub use self::utils::{inflate_bytes, inflate_bytes_zlib};

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -10,7 +10,7 @@ use InflateStream;
 /// # Example
 ///
 /// ```
-/// use inflate::writer::InflateWriter;
+/// use inflate::InflateWriter;
 /// use std::io::Write;
 ///
 /// let encoded = [243, 72, 205, 201, 201, 215, 81, 40, 207, 47, 202, 73, 1, 0];


### PR DESCRIPTION
This small patch just exposes `InflateWriter` on top-level instead of exposing the the `writer` module as suggest by @nwin in #12.