### PR TITLE
Implement readers and zlib checksum validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ keywords = ["deflate", "decompression", "compression", "piston"]
 [features]
 default = []
 unstable = []
+
+[dependencies]
+adler32 = "1.0.0"

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,0 +1,87 @@
+use adler32::RollingAdler32;
+
+pub fn adler32_from_bytes(bytes: &[u8]) -> u32 {
+    assert!(bytes.len() >= 4);
+    let val: u32 = (bytes[0] as u32) | ((bytes[1] as u32) << 8) |
+       ((bytes[2] as u32) << 16) | ((bytes[3] as u32) << 24);
+    u32::from_be(val)
+}
+
+/// Whether we should validate the checksum, and what type of checksum it is.
+pub enum ChecksumType {
+    /// No validation.
+    ///
+    /// For raw deflate streams or when we don't bother checking.
+    None,
+    /// Adler32
+    ///
+    /// Used in the zlib format.
+    Adler32(RollingAdler32),
+}
+
+pub struct Checksum {
+    checksum_type: ChecksumType,
+}
+
+impl Checksum {
+    #[inline]
+    pub fn none() -> Checksum {
+        Checksum::new(ChecksumType::None)
+    }
+
+    #[inline]
+    pub fn zlib() -> Checksum {
+        Checksum::new(ChecksumType::Adler32(RollingAdler32::new()))
+    }
+
+    pub fn new(checksum_type: ChecksumType) -> Checksum {
+        Checksum {
+            checksum_type: checksum_type,
+        }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        println!("Updating adler..");
+        match self.checksum_type {
+            ChecksumType::None => (),
+            ChecksumType::Adler32(ref mut c) => {
+                println!("Checksummed {} bytes.", bytes.len());
+                c.update_buffer(bytes);
+            }
+        }
+    }
+
+    pub fn check(&self, expected: u32) -> Result<(), String> {
+        match self.checksum_type {
+            ChecksumType::None => Ok(()),
+            ChecksumType::Adler32(ref c) => {
+                if c.hash() == expected {
+                    Ok(())
+                } else {
+                    Err("Checksum mismatch!".to_owned())
+                }
+            },
+        }
+
+    }
+
+    #[inline]
+    pub fn current_value(&self) -> u32 {
+        match self.checksum_type {
+            ChecksumType::Adler32(ref c) => c.hash(),
+            _ => 0,
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod test {
+    use super::adler32_from_bytes;
+
+    #[test]
+    fn adler32() {
+        let bytes = vec![0x00, 0x00, 0x01, 0x0b];
+        assert_eq!(adler32_from_bytes(&bytes[..]), 267);
+    }
+}

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -40,12 +40,11 @@ impl Checksum {
         }
     }
 
+    #[inline]
     pub fn update(&mut self, bytes: &[u8]) {
-        println!("Updating adler..");
         match self.checksum_type {
             ChecksumType::None => (),
             ChecksumType::Adler32(ref mut c) => {
-                println!("Checksummed {} bytes.", bytes.len());
                 c.update_buffer(bytes);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ pub use self::writer::{InflateWriter};
 mod utils;
 pub use self::utils::{inflate_bytes, inflate_bytes_zlib};
 
+mod reader;
+pub use self::reader::{DeflateDecoder, DeflateDecoderBuf};
+
 static BIT_REV_U8: [u8; 256] = [
     0b0000_0000, 0b1000_0000, 0b0100_0000, 0b1100_0000,
     0b0010_0000, 0b1010_0000, 0b0110_0000, 0b1110_0000,
@@ -557,6 +560,18 @@ impl InflateStream {
     /// Create a new stream for decoding deflate encoded data with a zlib header and footer
     pub fn from_zlib() -> InflateStream {
         InflateStream::with_state_and_buffer(ZlibMethodAndFlags, Vec::new())
+    }
+
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+        self.pos = 0;
+        self.state = Some(Bits(BlockHeader, BitState { n: 0, v: 0 }));
+        self.final_block = false;
+    }
+
+    pub fn reset_to_zlib(&mut self) {
+        self.reset();
+        self.state = Some(ZlibMethodAndFlags);
     }
 
     fn with_state_and_buffer(state: State, buffer: Vec<u8>) -> InflateStream {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,234 @@
+use std::io::{BufRead, Read, BufReader, self, Error, ErrorKind};
+use std::{cmp,mem};
+
+use super::InflateStream;
+
+/// A DEFLATE decoder/decompressor.
+///
+/// This structuree implements a `BufRead` interface and takes a stream of compressed data as input,
+/// provoding the decompressed data when read from.
+pub struct DeflateDecoderBuf<R> {
+    /// The inner reader instance
+    reader: R,
+    /// The raw decompressor
+    decompressor: InflateStream,
+    /// How many bytes of the decompressor's output buffer still need to be output.
+    pending_output_bytes: usize,
+    /// Total number of bytes read from the underlying reader.
+    total_in: u64,
+    /// Total number of bytes written in `read` calls.
+    total_out: u64,
+}
+
+impl<R: BufRead> DeflateDecoderBuf<R> {
+    pub fn new(reader: R) -> DeflateDecoderBuf<R> {
+        DeflateDecoderBuf {
+            reader: reader,
+            decompressor: InflateStream::new(),
+            pending_output_bytes: 0,
+            total_in: 0,
+            total_out: 0,
+        }
+    }
+}
+
+impl<R> DeflateDecoderBuf<R> {
+    /// Resets the decompressor, and replaces the current inner `BufRead` instance by `r`.
+    /// without doing any extra reallocations.
+    ///
+    /// Note that this function doesn't ensure that all data has been output.
+    pub fn reset(&mut self, r: R) -> R {
+        self.decompressor.reset();
+        mem::replace(&mut self.reader, r)
+    }
+
+    /// Resets the decoder, but continue to read from the same reader.
+    ///
+    /// Note that this function doesn't ensure that all data has been output.
+    pub fn reset_data(&mut self) {
+        self.decompressor.reset()
+    }
+
+    /// Returns a reference to the underlying `BufRead` instance.
+    pub fn get_ref(&self) -> &R {
+        &self.reader
+    }
+
+    /// Returns a mutable reference to the underlying `BufRead` instance.
+    ///
+    /// Note that mutation of the reader may cause surprising results if the decoder is going to
+    /// keep being used.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    /// Drops the decoder and return the inner `BufRead` instance.
+    ///
+    /// Note that this function doesn't ensure that all data has been output.
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
+
+    /// Returns the total bytes read from the underlying `BufRead` instance.
+    pub fn total_in(&self) -> u64 {
+        self.total_in
+    }
+
+    /// Returns the total number of bytes output from this decoder.
+    pub fn total_out(&self) -> u64 {
+        self.total_out
+    }
+}
+
+impl<R: BufRead> Read for DeflateDecoderBuf<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_out = 0;
+        // If there is still data left to ouput from the last call to `update()`, that needs to be
+        // output first
+        if self.pending_output_bytes != 0 {
+            // Get the part of the buffer that has not been output yet.
+            // The decompressor sets `pos` to 0 when it reaches the end of it's internal buffer,
+            // so we have to check for that.
+            let start = if self.decompressor.pos != 0 {
+                self.decompressor.pos as usize - self.pending_output_bytes
+            } else {
+                self.decompressor.buffer.len() - self.pending_output_bytes
+            };
+
+            // Copy as much decompressed as possible to buf.
+            let bytes_to_copy = cmp::min(buf.len(), self.pending_output_bytes);
+            let pending_data =
+                &self.decompressor.buffer[start..
+                                          start + bytes_to_copy];
+            buf[..bytes_to_copy].copy_from_slice(pending_data);
+            bytes_out += bytes_to_copy;
+            // This won't underflow since `bytes_to_copy` will be at most
+            // the same value as `pending_output_bytes`.
+            self.pending_output_bytes -= bytes_to_copy;
+            if self.pending_output_bytes != 0 {
+                self.total_out += bytes_out as u64;
+                // If there is still decompressed data left that didn't
+                // fit in `buf`, return what we read.
+                return Ok(bytes_out);
+            }
+        }
+
+        // There is space in `buf` for more data, so try to read more.
+        let (input_bytes_read, remaining_bytes) = {
+            self.pending_output_bytes = 0;
+            let input = try!(self.reader.fill_buf());
+            if input.len() == 0 {
+                self.total_out += bytes_out as u64;
+                //If there is nothing more to read, return.
+                return Ok(bytes_out);
+            }
+            let (input_bytes_read, data) =
+                match self.decompressor.update(&input) {
+                    Ok(res) => res,
+                    Err(m) => return Err(Error::new(ErrorKind::Other, m))
+                };
+
+            // Space left in `buf`
+            let space_left = buf.len() - bytes_out;
+            let bytes_to_copy = cmp::min(space_left, data.len());
+            buf[bytes_out..bytes_out + bytes_to_copy].copy_from_slice(&data[..bytes_to_copy]);
+
+            bytes_out += bytes_to_copy;
+
+            // Can't underflow as bytes_to_copy is bounded by data.len().
+            (input_bytes_read, data.len() - bytes_to_copy)
+
+        };
+
+        self.pending_output_bytes += remaining_bytes;
+        self.total_in += input_bytes_read as u64;
+        self.total_out += bytes_out as u64;
+        self.reader.consume(input_bytes_read);
+
+        Ok(bytes_out)
+    }
+}
+
+
+
+/// A DEFLATE decoder/decompressor.
+///
+/// This structuree implements a `Read` interface and takes a stream of compressed data as input,
+/// provoding the decompressed data when read from.
+pub struct DeflateDecoder<R> {
+    /// Inner DeflateDecoderBuf, with R wrapped in a `BufReader`.
+    inner: DeflateDecoderBuf<BufReader<R>>
+}
+
+impl<R: Read> DeflateDecoder<R> {
+    pub fn new(reader: R) -> DeflateDecoder<R> {
+        DeflateDecoder {
+            inner: DeflateDecoderBuf::new(BufReader::new(reader))
+        }
+    }
+
+    /// Resets the decompressor, and replaces the current inner `BufRead` instance by `r`.
+    /// without doing any extra reallocations.
+    ///
+    /// Note that this function doesn't ensure that all data has been output.
+    pub fn reset(&mut self, r: R) -> R {
+        self.inner.reset(BufReader::new(r)).into_inner()
+    }
+
+    /// Returns a reference to the underlying reader.
+    pub fn get_ref(&self) -> &R {
+        self.inner.get_ref().get_ref()
+    }
+
+    /// Returns a mutable reference to the underlying reader.
+    ///
+    /// Note that mutation of the reader may cause surprising results if the decoder is going to
+    /// keep being used.
+    pub fn get_mut(&mut self) -> &mut R {
+        self.inner.get_mut().get_mut()
+    }
+
+    /// Returns the total number of bytes output from this decoder.
+    pub fn into_inner(self) -> R {
+        self.inner.into_inner().into_inner()
+    }
+}
+
+impl<R> DeflateDecoder<R> {
+    /// Resets the decoder, but continue to read from the same reader.
+    ///
+    /// Note that this function doesn't ensure that all data has been output.
+    pub fn reset_data(&mut self) {
+        self.inner.reset_data()
+    }
+
+    /// Returns the total bytes read from the underlying reader.
+    pub fn total_in(&self) -> u64 {
+        self.inner.total_in
+    }
+
+    /// Returns the total number of bytes output from this decoder.
+    pub fn total_out(&self) -> u64 {
+        self.inner.total_out
+    }
+}
+
+impl<R: BufRead> Read for DeflateDecoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{DeflateDecoder};
+
+    #[test]
+    fn deflate_reader() {
+        let encoded = vec![243, 72, 205, 201, 201, 215, 81, 40, 207, 47, 202, 73, 1, 0];
+        let mut decoder = DeflateDecoder::new(encoded.as_slice());
+        let mut output = Vec::new();
+        decoder.read_to_end(&mut output).unwrap();
+        assert_eq!(String::from_utf8(output).unwrap(), "Hello, world");
+    }
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,6 +4,7 @@ use std::{cmp,mem};
 use super::InflateStream;
 
 /// Workaround for lack of copy_from_slice on pre-1.9 rust.
+#[inline]
 fn copy_from_slice(mut to: &mut [u8], from: &[u8]) {
     assert_eq!(to.len(), from.len());
     to.write_all(from).unwrap();
@@ -82,6 +83,7 @@ impl<R> DeflateDecoderBuf<R> {
     /// without doing any extra reallocations.
     ///
     /// Note that this function doesn't ensure that all data has been output.
+    #[inline]
     pub fn reset(&mut self, r: R) -> R {
         self.decompressor.reset();
         mem::replace(&mut self.reader, r)
@@ -90,11 +92,13 @@ impl<R> DeflateDecoderBuf<R> {
     /// Resets the decoder, but continue to read from the same reader.
     ///
     /// Note that this function doesn't ensure that all data has been output.
+    #[inline]
     pub fn reset_data(&mut self) {
         self.decompressor.reset()
     }
 
     /// Returns a reference to the underlying `BufRead` instance.
+    #[inline]
     pub fn get_ref(&self) -> &R {
         &self.reader
     }
@@ -103,6 +107,7 @@ impl<R> DeflateDecoderBuf<R> {
     ///
     /// Note that mutation of the reader may cause surprising results if the decoder is going to
     /// keep being used.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.reader
     }
@@ -110,16 +115,19 @@ impl<R> DeflateDecoderBuf<R> {
     /// Drops the decoder and return the inner `BufRead` instance.
     ///
     /// Note that this function doesn't ensure that all data has been output.
+    #[inline]
     pub fn into_inner(self) -> R {
         self.reader
     }
 
     /// Returns the total bytes read from the underlying `BufRead` instance.
+    #[inline]
     pub fn total_in(&self) -> u64 {
         self.total_in
     }
 
     /// Returns the total number of bytes output from this decoder.
+    #[inline]
     pub fn total_out(&self) -> u64 {
         self.total_out
     }
@@ -127,6 +135,7 @@ impl<R> DeflateDecoderBuf<R> {
     /// Returns the calculated checksum value of the currently decoded data.
     ///
     /// Will return 0 for cases where the checksum is not validated.
+    #[inline]
     pub fn current_checksum(&self) -> u32 {
         self.decompressor.current_checksum()
     }
@@ -253,11 +262,13 @@ impl<R: Read> DeflateDecoder<R> {
     /// without doing any extra reallocations.
     ///
     /// Note that this function doesn't ensure that all data has been output.
+    #[inline]
     pub fn reset(&mut self, r: R) -> R {
         self.inner.reset(BufReader::new(r)).into_inner()
     }
 
     /// Returns a reference to the underlying reader.
+    #[inline]
     pub fn get_ref(&self) -> &R {
         self.inner.get_ref().get_ref()
     }
@@ -266,11 +277,13 @@ impl<R: Read> DeflateDecoder<R> {
     ///
     /// Note that mutation of the reader may cause surprising results if the decoder is going to
     /// keep being used.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut R {
         self.inner.get_mut().get_mut()
     }
 
     /// Returns the total number of bytes output from this decoder.
+    #[inline]
     pub fn into_inner(self) -> R {
         self.inner.into_inner().into_inner()
     }
@@ -280,16 +293,19 @@ impl<R> DeflateDecoder<R> {
     /// Resets the decoder, but continue to read from the same reader.
     ///
     /// Note that this function doesn't ensure that all data has been output.
+    #[inline]
     pub fn reset_data(&mut self) {
         self.inner.reset_data()
     }
 
     /// Returns the total bytes read from the underlying reader.
+    #[inline]
     pub fn total_in(&self) -> u64 {
         self.inner.total_in
     }
 
     /// Returns the total number of bytes output from this decoder.
+    #[inline]
     pub fn total_out(&self) -> u64 {
         self.inner.total_out
     }
@@ -297,12 +313,14 @@ impl<R> DeflateDecoder<R> {
     /// Returns the calculated checksum value of the currently decoded data.
     ///
     /// Will return 0 for cases where the checksum is not validated.
+    #[inline]
     pub fn current_checksum(&self) -> u32 {
         self.inner.current_checksum()
     }
 }
 
 impl<R: Read> Read for DeflateDecoder<R> {
+    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
     }


### PR DESCRIPTION
Fixes #10

This PR adds decoders that implement `Read` similar to the ones in flate2.
I tried to mostly follow the flate2 API, though I added seperate constructors rather than different structs for zlib/non-zlib. 

This PR also adds support for validating the adler32 checksum in zlib-wrapped streams. It is done by default, however I added options to not checksum for purposes where one wants to avoid the overhead. (Granted, adler32 is pretty fast.)