### PR TITLE
Fix a panic on non-existent checksum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1061,6 +1061,9 @@ impl InflateStream {
                 ok_bytes!(data.len(), Uncompressed(len))
             }
             CheckCRC => {
+                if data.len() < 4 {
+                    return Err("data stream ends without a checksum".into());
+                }
                 // Get the checksum value from the end of the stream.
                 self.read_checksum = Some(adler32_from_bytes(data));
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -36,3 +36,12 @@ fn issue_17() {
     let res = stream.update(data);
     assert!(res.is_err());
 }
+
+#[test]
+// no checksum present at the end of the data stream (cargo-fuzz test-case)
+fn no_checksum() {
+    let data = b"\x13\xff\xed\xff\xff\x12\xbfM\x00\x00\x00\x00\xd1";
+    let mut stream = inflate::InflateStream::new();
+    let res = stream.update(data);
+    assert!(res.is_err());
+}


### PR DESCRIPTION
panicked on `assert!(bytes.len() >= 4);` in `adler32_from_bytes`.