### PR TITLE
Fix reading CRC when there is a full byte still in the BitStream

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,7 +1,6 @@
 use adler32::RollingAdler32;
 
-pub fn adler32_from_bytes(bytes: &[u8]) -> u32 {
-    assert!(bytes.len() >= 4);
+pub fn adler32_from_bytes(bytes: &[u8; 4]) -> u32 {
     let val: u32 = (bytes[0] as u32) | ((bytes[1] as u32) << 8) |
        ((bytes[2] as u32) << 16) | ((bytes[3] as u32) << 24);
     u32::from_be(val)
@@ -27,6 +26,14 @@ impl Checksum {
     #[inline]
     pub fn none() -> Checksum {
         Checksum::new(ChecksumType::None)
+    }
+
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        match self.checksum_type {
+            ChecksumType::None => true,
+            _ => false,
+        }
     }
 
     #[inline]
@@ -80,7 +87,7 @@ mod test {
 
     #[test]
     fn adler32() {
-        let bytes = vec![0x00, 0x00, 0x01, 0x0b];
-        assert_eq!(adler32_from_bytes(&bytes[..]), 267);
+        let bytes = [0x00, 0x00, 0x01, 0x0b];
+        assert_eq!(adler32_from_bytes(&bytes), 267);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,4 +70,17 @@ mod test {
                        76, 82, 4, 0, 0, 0, 0, 0];
         inflate_bytes_zlib(&encoded).unwrap_err();
     }
+
+    #[test]
+    fn inflate_bytes_with_zlib_trailing() {
+        use super::inflate_bytes_zlib;
+        use std::str::from_utf8;
+
+        // The additional 4 bytes should be ignored.
+        let encoded = [120, 156, 243, 72, 205, 201, 201, 215, 81, 168, 202, 201,
+                       76, 82, 4, 0, 27, 101, 4, 19, 0, 0, 0, 0];
+        let decoded = inflate_bytes_zlib(&encoded).unwrap();
+        assert!(from_utf8(&decoded).unwrap() == "Hello, zlib!");
+    }
+
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -43,5 +43,19 @@ fn no_checksum() {
     let data = b"\x13\xff\xed\xff\xff\x12\xbfM\x00\x00\x00\x00\xd1";
     let mut stream = inflate::InflateStream::new();
     let res = stream.update(data);
-    assert!(res.is_err());
+    // This is not an error, because the checksum may be included in the next
+    // call to `stream.update`. See issue #27.
+    assert!(res.is_ok());
+}
+
+#[test]
+/// The first byte of the CRC is already read into the BitStream buffer.
+fn issue_26() {
+    let data = &[120, 156, 189, 138, 65, 13, 0, 32, 16, 195, 64, 2, 22, 176, 128, 5, 44, 96, 1, 11,
+        216, 103, 19, 176, 123, 118, 73, 155, 61, 218, 155, 54, 10, 136, 192, 170, 32, 130, 41,
+        249, 36, 136, 96, 73, 62, 9, 34, 216, 146, 79, 130, 8, 142, 228, 147, 32, 130, 43, 249, 36,
+        136, 224, 73, 62, 9, 32, 248, 250, 192, 22, 113, 123];
+    let mut stream = inflate::InflateStream::from_zlib();
+    let res = stream.update(data);
+    assert!(res.is_ok());
 }


### PR DESCRIPTION
Fixes #26

Also fixes handling of trailing bytes. We now discard them, instead of treating them as additional CRCs.