### PR TITLE
Drop some `unsafe`s - the compiler now optimizes equivalent safe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["deflate", "decompression", "compression", "piston"]
 
 [features]
 default = []
+unstable = []
 
 [dependencies]
 adler32 = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["deflate", "decompression", "compression", "piston"]
 
 [features]
 default = []
-unstable = []
 
 [dependencies]
 adler32 = "1.0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,16 +658,15 @@ impl InflateStream {
             (buffer_size, Some(pos_end - buffer_size))
         };
 
+        if self.pos < dist && pos_end > self.pos {
+            return Err("invalid run length in stream".to_owned());
+        }
+
         if self.buffer.len() < pos_end as usize {
             unsafe {
                 self.buffer.set_len(pos_end as usize);
             }
         }
-
-        if self.pos < dist && pos_end > self.pos {
-            return Err("invalid run length in stream".to_owned());
-        }
-
         for i in self.pos as usize..pos_end as usize {
         self.buffer[i] = self.buffer[i - dist as usize]
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -658,6 +658,7 @@ impl InflateStream {
                 self.buffer.set_len(pos_end as usize);
             }
         }
+        assert!(dist > 0);
         for i in self.pos as usize..pos_end as usize {
             self.buffer[i] = self.buffer[i - dist as usize];
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,7 +643,7 @@ impl InflateStream {
             }
 
             for i in self.pos as usize..pos_end as usize {
-            self.buffer[i] = self.buffer[i + forward as usize]
+                self.buffer[i] = self.buffer[i + forward as usize]
             }
             self.pos = pos_end;
             left

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,10 @@ impl InflateStream {
     fn run_len_dist(&mut self, len: u16, dist: u16) -> Result<Option<u16>, String> {
         debug!("RLE -{}; {} (cap={} len={})", dist, len,
                self.buffer.capacity(), self.buffer.len());
+        // `dist > 0` validation is cruicual for unsafe block below.
+        // Not validating it would let an attacker obtain contents of uninitialized memory,
+        // which is a serious security vulnerability for e.g. PNG decoders using this crate.
+        // See http://seclists.org/fulldisclosure/2013/Nov/83 for such vulns in C libs.
         if dist < 1 {
             return Err("invalid run length in stream".to_owned());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,7 @@ impl CodeLengthReader {
                         self.result.push(0);
                     }
                 }
-                _ => panic!(),
+                _ => unreachable!(),
             }
         }
         Ok(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,10 +607,6 @@ impl InflateStream {
     fn run_len_dist(&mut self, len: u16, dist: u16) -> Result<Option<u16>, String> {
         debug!("RLE -{}; {} (cap={} len={})", dist, len,
                self.buffer.capacity(), self.buffer.len());
-        // `dist > 0` validation is cruicual for unsafe block below.
-        // Not validating it would let an attacker obtain contents of uninitialized memory,
-        // which is a serious security vulnerability for e.g. PNG decoders using this crate.
-        // See http://seclists.org/fulldisclosure/2013/Nov/83 for such vulns in C libs.
         if dist < 1 {
             return Err("invalid run length in stream".to_owned());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,7 +649,9 @@ impl InflateStream {
         }
 
         if self.buffer.len() < pos_end as usize {
+            // ensure the buffer length will not exceed the amount of allocated memory
             assert!(pos_end <= buffer_size);
+            // ensure that the uninitialized chunk of memory will be fully overwritten
             assert!(self.pos as usize <= self.buffer.len());
             unsafe {
                 self.buffer.set_len(pos_end as usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -649,6 +649,7 @@ impl InflateStream {
 
         if self.buffer.len() < pos_end as usize {
             assert!(pos_end <= buffer_size);
+            assert!(self.pos as usize <= self.buffer.len());
             unsafe {
                 self.buffer.set_len(pos_end as usize);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,6 +625,9 @@ impl InflateStream {
     fn run_len_dist(&mut self, len: u16, dist: u16) -> Result<Option<u16>, String> {
         debug!("RLE -{}; {} (cap={} len={})", dist, len,
                self.buffer.capacity(), self.buffer.len());
+        if dist < 1 {
+            return Err("invalid run length in stream".to_owned());
+        }
         let buffer_size = self.buffer.capacity() as u16;
         let len = if self.pos < dist {
             // Handle copying from ahead, until we hit the end reading.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! }
 //! ```
 
-#![cfg_attr(feature = "unstable", feature(core))]
+#![cfg_attr(feature = "unstable", feature(core_intrinsics))]
 
 extern crate adler32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,7 +643,7 @@ impl InflateStream {
             }
 
             for i in self.pos as usize..pos_end as usize {
-                self.buffer[i] = self.buffer[i + forward as usize]
+                self.buffer[i] = self.buffer[i + forward as usize];
             }
             self.pos = pos_end;
             left

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,6 +614,7 @@ impl InflateStream {
         if dist < 1 {
             return Err("invalid run length in stream".to_owned());
         }
+        // `buffer_size` is used for validating `unsafe` below, handle with care
         let buffer_size = self.buffer.capacity() as u16;
         let len = if self.pos < dist {
             // Handle copying from ahead, until we hit the end reading.
@@ -658,7 +659,7 @@ impl InflateStream {
                 self.buffer.set_len(pos_end as usize);
             }
         }
-        assert!(dist > 0);
+        assert!(dist > 0); // validation against reading uninitialized memory
         for i in self.pos as usize..pos_end as usize {
             self.buffer[i] = self.buffer[i - dist as usize];
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,7 +668,7 @@ impl InflateStream {
             }
         }
         for i in self.pos as usize..pos_end as usize {
-        self.buffer[i] = self.buffer[i - dist as usize]
+            self.buffer[i] = self.buffer[i - dist as usize];
         }
         self.pos = pos_end;
         Ok(left)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,6 +648,7 @@ impl InflateStream {
         }
 
         if self.buffer.len() < pos_end as usize {
+            assert!(pos_end <= buffer_size);
             unsafe {
                 self.buffer.set_len(pos_end as usize);
             }


### PR DESCRIPTION
This PR drops some unsafe code that was introduced in place of safe code as an optimization. It is no longer needed: on Rust 1.27 (current stable) performance degradation from this change is within measurement noise even when taking 10x the normal number of samples using Criterion.

`cargo bench` has 2% variance by itself, so it couldn't measure anything below that, so I had to switch to Criterion and then jack up the number of samples to make sure there is no degradation at all. You can find the benchmarking setup [here](https://github.com/Shnatsel/inflate/tree/benchmarking). It's a bit messy, but I can clean it up and open a PR if you're interested.